### PR TITLE
Fixed Flush and Drop buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Also, if you have any suggestions, whether it's a new feature proposal or a bug,
 [Daniele Avolio](https://github.com/danieleavolio)
 
 # Donation
-You can buy me a coffe:
+I do believe in free information, so do not feel obligated to donate something. If, however, you still want you can buy me a coffe... :eyes:
 
 [![](https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif)](https://www.paypal.com/donate/?hosted_button_id=W8ZTJHH89TJJL)
 

--- a/src/app/rules/rules.component.html
+++ b/src/app/rules/rules.component.html
@@ -239,6 +239,6 @@
   </table>
   <div>
     <h3>For more exhaustive explanation, consult the <a href="https://linux.die.net/man/8/iptables">iptables man page</a></h3>
-    <h4>If you find any bug or want to suggest something, open an issue in the <a href="https://github.com/Claudiocli/Iptables-Rule-Generator">GitHub repo</a><br/>You can always <a href="https://www.paypal.com/donate/?hosted_button_id=W8ZTJHH89TJJL">support us</a></h4>
+    <h4>If you find any bug or want to suggest something, open an issue in the <a href="https://github.com/Claudiocli/Iptables-Rule-Generator">GitHub repo</a><br/>We fully support free knowledge, but you can always <a href="https://www.paypal.com/donate/?hosted_button_id=W8ZTJHH89TJJL">support us</a></h4>
   </div>
 </div>

--- a/src/app/rules/rules.component.ts
+++ b/src/app/rules/rules.component.ts
@@ -99,17 +99,19 @@ export class RulesComponent {
 
 
   public copyToClipboard() {
-    const el = document.createElement('textarea');
-    this.has_been_copied = true;
-    el.value = this.outputRule();
-    document.body.appendChild(el);
-    el.select();
-    document.execCommand('copy');
-    document.body.removeChild(el);
-    document.getElementById('clipboard-text')?.classList.add('vanishing');
-    setTimeout(() => {
-      document.getElementById('clipboard-text')?.classList.remove('vanishing');
-    }, 6000);
+    const clip_text = this.f_option ? 'iptables -F; ' : '';
+    clip_text += this.x_option ? 'iptables -X; ' : '';
+    clip_text += this.outputRule();
+    navigator.clipboard.writeText(clip_text).then(() => {
+      this.has_been_copied = true;
+      const clip_element = document.getElementById('clipboard-text');
+      clip_element?.classList.add('vanishing');
+      setTimeout(() => {
+        clip_element?.classList.remove('vanishing');
+      }, 6000);
+    }).catch(err => {
+      console.error('Failed to copy rule to clipboard: ', err);
+    });
   }
 
 }


### PR DESCRIPTION
Fixed "Flush all the chains" and "Delete all not-builtin chains", they will add the correct commands when the rule is copied. Also, resolved [deprecation of execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API)

Small change on readme and on main page